### PR TITLE
Fixes #8 - Makes markdown optional

### DIFF
--- a/hangouts_chat.py
+++ b/hangouts_chat.py
@@ -252,12 +252,16 @@ class GoogleHangoutsChatBackend(ErrBot):
         super(GoogleHangoutsChatBackend, self).send_message(message)
         log.info("Sending {}".format(message.body))
         space_id = message.extras.get('space_id', None)
+        convert_markdown = message.extras.get('markdown', True)
         if not space_id:
             log.info(message.body)
             return
         thread_id = message.extras.get('thread_id', None)
+        text = message.body
+        if convert_markdown:
+            text = self.md.convert(message.body)
         message_payload = {
-            'text': self.md.convert(message.body)
+            'text': text
         }
 
         if thread_id:


### PR DESCRIPTION
This commit adds the ability to specify an extra option in the `extras`
blob which skips markdown processing on the message being sent, if for
example you've done your own formatting